### PR TITLE
update Power part

### DIFF
--- a/src/main/java/com/marcinmoskala/math/Power.kt
+++ b/src/main/java/com/marcinmoskala/math/Power.kt
@@ -2,4 +2,17 @@
 @file:JvmMultifileClass
 package com.marcinmoskala.math
 
-fun Int.pow(power: Int): Int = Math.pow(this.toDouble(), power.toDouble()).toInt()
+infix fun Double.pow(other: Number): Double = Math.pow(this, other.toDouble())
+
+infix fun Float.pow(other: Number): Float = Math.pow(this.toDouble(), other.toDouble()).toFloat()
+
+infix fun Long.pow(other: Number): Long = Math.pow(this.toDouble(), other.toDouble()).toLong()
+
+infix fun Int.pow(other: Number): Int = Math.pow(this.toDouble(), other.toDouble()).toInt()
+
+infix fun Short.pow(other: Number): Short = Math.pow(this.toDouble(), other.toDouble()).toShort()
+
+infix fun Byte.pow(other: Number): Byte = Math.pow(this.toDouble(), other.toDouble()).toByte()
+
+// we have all Number types for pow that returns their types but this is for all that returns Double
+infix fun Number.pow(other: Number): Double = Math.pow(this.toDouble(), other.toDouble())


### PR DESCRIPTION
in this commits:
* add `pow` function for all Number types returning their same number type
* add `Number.pow` function that accepts all type of numbers and return `Double`
* makes `pow` function `infix` so that functions can use `1 pow 2` or `3.pow(4)`
* `pow` now accepts all types of `Number`s like `3.5 pow 2` or `3f pow 8` or `8.pow(6L)`