### PR TITLE
Add cartesian product of lists to the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,38 @@ listOf('a', 'b') * listOf(1, 2) * listOf("A", "B") // returns List<Triple<Char, 
 
 More examples [here](https://github.com/MarcinMoskala/KotlinDiscreteMathToolkit/blob/master/src/test/java/com/marcinmoskala/math/tests/IterableMultipliationTest.kt).
 
+# Cartesian product of lists
+
+Similar to iterable multiplication but produces sequence of lists:
+
+```kotlin
+listOf('A', 'B', 'C', D).cartesianProduct(listOf('x', 'y')) // returns List<List<Char>>
+// [
+//     ['A', 'x'],
+//     ['A', 'y'],
+//     ['B', 'x'],
+//     ['B', 'y'],
+//     ['C', 'x'],
+//     ['C', 'y'],
+//     ['D', 'x'],
+//     ['D', 'y']
+// ]
+listOf(0, 1).cartesianProduct(repeat = 2) // returns List<List<Int>>
+// [
+//     [0, 0],
+//     [0, 1],
+//     [1, 0],
+//     [1, 1]
+// ]
+listOf(1, 2).cartesianProduct(listOf("ABC")) // returns List<List<Any>>
+// [
+//     [1, "ABC"],
+//     [2, "ABC"]
+// ]
+```
+
+More examples [here](https://github.com/MarcinMoskala/KotlinDiscreteMathToolkit/blob/master/src/test/java/com/marcinmoskala/math/tests/CartesianProductTest.kt).
+
 # Java support
 
 Library is fully supporting usage from Java. All functions can be used as static function of DiscreteMath. For example:

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ apply plugin: "jacoco"
 buildscript {
     ext.kotlin_version = '1.3.72'
     ext.junit_version = '5.6.1'
+    ext.kotest_version = '4.0.6'
     repositories {
         mavenCentral()
     }
@@ -29,8 +30,10 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testCompile "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+    testImplementation "io.kotest:kotest-runner-junit5-jvm:$kotest_version"
+    testImplementation "io.kotest:kotest-property-jvm:$kotest_version"
 }
 
 task javadocJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,8 @@ apply plugin: 'signing'
 apply plugin: "jacoco"
 
 buildscript {
-    ext.kotlin_version = '1.2.0'
+    ext.kotlin_version = '1.3.72'
+    ext.junit_version = '5.6.1'
     repositories {
         mavenCentral()
     }
@@ -28,7 +29,8 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testCompile 'junit:junit:4.12'
+    testCompile "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_version"
 }
 
 task javadocJar(type: Jar) {
@@ -99,6 +101,7 @@ uploadArchives {
 }
 
 tasks.withType(Test) {
+    useJUnitPlatform()
     testLogging {
         // set options for log level LIFECYCLE
         events "passed", "skipped", "failed", "standardOut"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 01 21:17:17 CEST 2017
+#Mon Jun 08 23:32:02 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip

--- a/src/main/java/com/marcinmoskala/math/CartesianProductExt.kt
+++ b/src/main/java/com/marcinmoskala/math/CartesianProductExt.kt
@@ -1,0 +1,37 @@
+@file:JvmName("DiscreteMath")
+@file:JvmMultifileClass
+
+package com.marcinmoskala.math
+
+@ExperimentalStdlibApi
+fun <T> List<T>.cartesianProduct(repeat: Int = 2): Sequence<List<T>> {
+    require(repeat > 0) { "Parameter repeat should be greater than 0" }
+    return productEx(*Array(repeat) { this })
+}
+
+@ExperimentalStdlibApi
+fun <T> List<T>.cartesianProduct(vararg lists: List<T>): Sequence<List<T>> =
+        productEx(this, *lists)
+
+@ExperimentalStdlibApi
+private fun <T> productEx(vararg iterables: List<T>): Sequence<List<T>> = sequence {
+    val numberOfIterables = iterables.size
+    val lstLengths = ArrayDeque<Int>()
+    val lstRemaining = ArrayDeque(listOf(1))
+
+    iterables.reversed().forEach {
+        lstLengths.addFirst(it.size)
+        lstRemaining.addFirst(it.size * lstRemaining[0])
+    }
+
+    val nProducts = lstRemaining.removeFirst()
+
+    (0 until nProducts).forEach { product ->
+        val result = ArrayDeque<T>()
+        (0 until numberOfIterables).forEach { iterableIndex ->
+            val elementIndex = product / lstRemaining[iterableIndex] % lstLengths[iterableIndex]
+            result.addLast(iterables[iterableIndex][elementIndex])
+        }
+        yield(result.toList())
+    }
+}

--- a/src/main/java/com/marcinmoskala/math/CartesianProductExt.kt
+++ b/src/main/java/com/marcinmoskala/math/CartesianProductExt.kt
@@ -3,34 +3,46 @@
 
 package com.marcinmoskala.math
 
-@ExperimentalStdlibApi
+/**
+ * Cartesian product of a list with itself, specify the number of repetitions with the optional repeat keyword argument.
+ * For example, A.cartesianProduct(repeat=4) means the same as A.cartesianProduct(A, A, A).
+ * Throws an [IllegalArgumentException]: if [repeat] is less or equals to 0
+ * Throws an [IllegalArgumentException]: if size of result should exceeds [Int.MAX_VALUE]
+ */
 fun <T> List<T>.cartesianProduct(repeat: Int = 2): Sequence<List<T>> {
     require(repeat > 0) { "Parameter repeat should be greater than 0" }
-    return productEx(*Array(repeat) { this })
+    return product(*Array(repeat) { this })
 }
 
-@ExperimentalStdlibApi
+/**
+ * Cartesian product of lists.
+ * Throws an [IllegalArgumentException]: if size of result should exceeds [Int.MAX_VALUE]
+ */
 fun <T> List<T>.cartesianProduct(vararg lists: List<T>): Sequence<List<T>> =
-        productEx(this, *lists)
+        product(this, *lists)
 
-@ExperimentalStdlibApi
-private fun <T> productEx(vararg iterables: List<T>): Sequence<List<T>> = sequence {
-    val numberOfIterables = iterables.size
-    val lstLengths = ArrayDeque<Int>()
-    val lstRemaining = ArrayDeque(listOf(1))
+private fun <T> product(vararg iterables: List<T>): Sequence<List<T>> = sequence {
 
-    iterables.reversed().forEach {
-        lstLengths.addFirst(it.size)
-        lstRemaining.addFirst(it.size * lstRemaining[0])
+    require(iterables.map { it.size.toLong() }.reduce(Long::times) <= Int.MAX_VALUE) {
+        "Cartesian product function can produce result whose size does not exceed Int.MAX_VALUE"
     }
 
-    val nProducts = lstRemaining.removeFirst()
+    val numberOfIterables = iterables.size
+    val lstLengths = ArrayList<Int>()
+    val lstRemaining = ArrayList(listOf(1))
+
+    iterables.reversed().forEach {
+        lstLengths.add(0, it.size)
+        lstRemaining.add(0, it.size * lstRemaining[0])
+    }
+
+    val nProducts = lstRemaining.removeAt(0)
 
     (0 until nProducts).forEach { product ->
-        val result = ArrayDeque<T>()
+        val result = ArrayList<T>()
         (0 until numberOfIterables).forEach { iterableIndex ->
             val elementIndex = product / lstRemaining[iterableIndex] % lstLengths[iterableIndex]
-            result.addLast(iterables[iterableIndex][elementIndex])
+            result.add(iterables[iterableIndex][elementIndex])
         }
         yield(result.toList())
     }

--- a/src/test/java/com/marcinmoskala/math/tests/CartesianProductPropertyTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/CartesianProductPropertyTest.kt
@@ -8,7 +8,6 @@ import io.kotest.property.arbitrary.list
 import io.kotest.property.forAll
 
 
-@ExperimentalStdlibApi
 internal class CartesianProductPropertyTest : StringSpec({
 
     val intListGen = Arb.list(
@@ -20,7 +19,6 @@ internal class CartesianProductPropertyTest : StringSpec({
             intListGen,
             2..5
     )
-
 
     "output product size is product of sizes of inputs" {
         forAll(listOfIntListsGen) { list ->

--- a/src/test/java/com/marcinmoskala/math/tests/CartesianProductPropertyTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/CartesianProductPropertyTest.kt
@@ -1,0 +1,66 @@
+package com.marcinmoskala.math.tests
+
+import com.marcinmoskala.math.cartesianProduct
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.forAll
+
+
+@ExperimentalStdlibApi
+internal class CartesianProductPropertyTest : StringSpec({
+
+    val intListGen = Arb.list(
+            Arb.int(0..100),
+            2..5
+    )
+
+    val listOfIntListsGen = Arb.list(
+            intListGen,
+            2..5
+    )
+
+
+    "output product size is product of sizes of inputs" {
+        forAll(listOfIntListsGen) { list ->
+            val head = list[0]
+            val tail = list.drop(1).toTypedArray()
+            head.cartesianProduct(*tail).toList().size == list.map { it.size }.reduce(Int::times)
+        }
+    }
+
+    "cartesian product with repeat of empty list is empty list" {
+        forAll(Arb.int(2..10)) { repeat ->
+            emptyList<Int>().cartesianProduct(repeat).toList().isEmpty()
+        }
+    }
+
+    "cartesian product of empty list and non empty list is empty list" {
+        forAll(intListGen) { list ->
+            emptyList<Int>().cartesianProduct(list).toList().isEmpty()
+        }
+    }
+
+    "cartesian product of non empty list and empty list is empty list" {
+        forAll(intListGen) { list ->
+            list.cartesianProduct(emptyList()).toList().isEmpty()
+        }
+    }
+
+    "set of elements in product is the same as in input" {
+        forAll(listOfIntListsGen) { list ->
+            val head = list[0]
+            val tail = list.drop(1).toTypedArray()
+            head.cartesianProduct(*tail).toList().flatten().toSet() ==
+                    list.flatten().toSet()
+        }
+    }
+
+//    TODO:
+//    - test "A","B" * 1,2 (heterogenous lists)
+//    - make sure prop test run on build
+//    - rewrite implementation to not use deck
+//    - README
+
+})

--- a/src/test/java/com/marcinmoskala/math/tests/CartesianProductPropertyTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/CartesianProductPropertyTest.kt
@@ -54,11 +54,4 @@ internal class CartesianProductPropertyTest : StringSpec({
                     list.flatten().toSet()
         }
     }
-
-//    TODO:
-//    - test "A","B" * 1,2 (heterogenous lists)
-//    - make sure prop test run on build
-//    - rewrite implementation to not use deck
-//    - README
-
 })

--- a/src/test/java/com/marcinmoskala/math/tests/CartesianProductTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/CartesianProductTest.kt
@@ -1,0 +1,132 @@
+package com.marcinmoskala.math.tests
+
+import com.marcinmoskala.math.cartesianProduct
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.next
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+
+@ExperimentalStdlibApi
+internal class CartesianProductTest {
+
+    @Test
+    fun `cartesian product with repeat less than 1 throws`() {
+        val repeat = Arb.int(-100..0).next()
+        assertThrows(IllegalArgumentException::class.java) {
+            listOf(1, 2, 3).cartesianProduct(repeat)
+        }
+    }
+
+    @Test
+    fun `cartesian product with repeat = 1`() {
+        val actual = listOf(1, 2, 3).cartesianProduct(1).toList()
+        val expected = listOf(
+                listOf(1),
+                listOf(2),
+                listOf(3)
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `cartesian product with repeat`() {
+        val actual = listOf(1, 2, 3).cartesianProduct(2).toList()
+        val expected = listOf(
+                listOf(1, 1),
+                listOf(1, 2),
+                listOf(1, 3),
+                listOf(2, 1),
+                listOf(2, 2),
+                listOf(2, 3),
+                listOf(3, 1),
+                listOf(3, 2),
+                listOf(3, 3)
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `cartesian product of different sizes`() {
+        val actual = listOf(1, 2, 3).cartesianProduct(listOf(8, 9)).toList()
+        val expected = listOf(
+                listOf(1, 8),
+                listOf(1, 9),
+                listOf(2, 8),
+                listOf(2, 9),
+                listOf(3, 8),
+                listOf(3, 9)
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `cartesian product of same sizes`() {
+        val actual = listOf(1, 2).cartesianProduct(listOf(8, 9)).toList()
+        val expected = listOf(
+                listOf(1, 8),
+                listOf(1, 9),
+                listOf(2, 8),
+                listOf(2, 9)
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `cartesian product of 3 lists`() {
+        val actual = listOf(1, 2).cartesianProduct(
+                listOf(3, 4),
+                listOf(5, 6)
+        ).toList()
+        val expected = listOf(
+                listOf(1, 3, 5),
+                listOf(1, 3, 6),
+                listOf(1, 4, 5),
+                listOf(1, 4, 6),
+                listOf(2, 3, 5),
+                listOf(2, 3, 6),
+                listOf(2, 4, 5),
+                listOf(2, 4, 6)
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `cartesian product of 3 lists with different size`() {
+        val actual = listOf(0, 1, 2).cartesianProduct(
+                listOf(3, 4),
+                listOf(5, 6)
+        ).toList()
+        val expected = listOf(
+                listOf(0, 3, 5),
+                listOf(0, 3, 6),
+                listOf(0, 4, 5),
+                listOf(0, 4, 6),
+                listOf(1, 3, 5),
+                listOf(1, 3, 6),
+                listOf(1, 4, 5),
+                listOf(1, 4, 6),
+                listOf(2, 3, 5),
+                listOf(2, 3, 6),
+                listOf(2, 4, 5),
+                listOf(2, 4, 6)
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `cartesian product of 2 lists with different types`() {
+        val expected = listOf(
+                listOf("A", 1),
+                listOf("A", 2),
+                listOf("A", 3),
+                listOf("B", 1),
+                listOf("B", 2),
+                listOf("B", 3)
+        )
+        val actual = listOf("A", "B").cartesianProduct(listOf(1, 2, 3)).toList()
+        assertEquals(expected, actual)
+    }
+}

--- a/src/test/java/com/marcinmoskala/math/tests/CartesianProductTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/CartesianProductTest.kt
@@ -9,8 +9,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 
 
-@ExperimentalStdlibApi
 internal class CartesianProductTest {
+
+    @Test
+    fun `cartesian product with size more than MAX_INT throws`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            listOf(1, 2, 3, 5, 6, 7, 8, 9, 0).cartesianProduct(10).toList()
+        }
+    }
 
     @Test
     fun `cartesian product with repeat less than 1 throws`() {

--- a/src/test/java/com/marcinmoskala/math/tests/CombinationTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/CombinationTest.kt
@@ -2,12 +2,13 @@ package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.combinations
 import com.marcinmoskala.math.combinationsNumber
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class CombinationTest {
 
-    @Test fun `combinations function is throwing error when asked for subsets of size smaller then 0`() {
+    @Test
+    fun `combinations function is throwing error when asked for subsets of size smaller then 0`() {
         val set = setOf(1, 2, 3, 4)
         for (subsetSize in -10..-1) {
             assertIsThrowingError { set.combinations(subsetSize) }

--- a/src/test/java/com/marcinmoskala/math/tests/CombinationWithRepetitionTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/CombinationWithRepetitionTest.kt
@@ -2,8 +2,8 @@ package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.combinationsWithRepetitions
 import com.marcinmoskala.math.combinationsWithRepetitionsNumber
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class CombinationWithRepetitionTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/FactorialTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/FactorialTest.kt
@@ -1,8 +1,8 @@
 package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.factorial
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class FactorialTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/IterableMultipliationTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/IterableMultipliationTest.kt
@@ -1,8 +1,8 @@
 package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.times
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class IterableMultipliationTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/JavaTest.java
+++ b/src/test/java/com/marcinmoskala/math/tests/JavaTest.java
@@ -1,9 +1,9 @@
 package com.marcinmoskala.math.tests;
 
 import com.marcinmoskala.math.DiscreteMath;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -15,7 +15,7 @@ public class JavaTest {
     private static Set<Integer> smallSet = new HashSet<>();
     private static List<Integer> smallList = new ArrayList<>();
 
-    @BeforeClass
+    @BeforeAll
     static public void setUp() {
         smallSet.add(0);
         smallSet.add(1);
@@ -27,43 +27,43 @@ public class JavaTest {
 
     @Test
     public void permutationsTest() {
-        Assert.assertEquals(6, DiscreteMath.permutationsNumber(smallSet));
-        Assert.assertEquals(3, DiscreteMath.permutationsNumber(smallList));
+        Assertions.assertEquals(6, DiscreteMath.permutationsNumber(smallSet));
+        Assertions.assertEquals(3, DiscreteMath.permutationsNumber(smallList));
     }
 
     @Test
     public void combinationsTest() {
-        Assert.assertEquals(3, DiscreteMath.combinationsNumber(smallSet, 2));
-        Assert.assertEquals(6, DiscreteMath.combinationsWithRepetitionsNumber(smallSet, 2));
+        Assertions.assertEquals(3, DiscreteMath.combinationsNumber(smallSet, 2));
+        Assertions.assertEquals(6, DiscreteMath.combinationsWithRepetitionsNumber(smallSet, 2));
     }
 
     @Test
     public void powersetTest() {
-        Assert.assertEquals(8, DiscreteMath.getPowersetSize(smallSet));
+        Assertions.assertEquals(8, DiscreteMath.getPowersetSize(smallSet));
     }
 
     @Test
     public void productTest() {
-        Assert.assertEquals(0, DiscreteMath.product(smallList));
+        Assertions.assertEquals(0, DiscreteMath.product(smallList));
     }
 
     @Test
     public void factorialTest() {
-        Assert.assertEquals(3628800L, DiscreteMath.factorial(10));
+        Assertions.assertEquals(3628800L, DiscreteMath.factorial(10));
     }
 
     @Test
     public void splitsOfSetTest() {
-        Assert.assertEquals(3, DiscreteMath.splitsNumber(smallSet, 2));
+        Assertions.assertEquals(3, DiscreteMath.splitsNumber(smallSet, 2));
     }
 
     @Test
     public void splitsOfNumberTest() {
-        Assert.assertEquals(3, DiscreteMath.splitsNumber(7, 4));
+        Assertions.assertEquals(3, DiscreteMath.splitsNumber(7, 4));
     }
 
     @Test
     public void iterableMultiplicationTest() {
-        Assert.assertEquals(smallList.size() * smallList.size(), DiscreteMath.times(smallList, smallList).size());
+        Assertions.assertEquals(smallList.size() * smallList.size(), DiscreteMath.times(smallList, smallList).size());
     }
 }

--- a/src/test/java/com/marcinmoskala/math/tests/NumberSplitTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/NumberSplitTest.kt
@@ -1,8 +1,8 @@
 package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.splitsNumber
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class NumberSplitTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/NumbersDivisibleTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/NumbersDivisibleTest.kt
@@ -4,8 +4,8 @@ import com.marcinmoskala.math.countDivisiveBy
 import com.marcinmoskala.math.countNonDivisiveBy
 import com.marcinmoskala.math.divisiveBy
 import com.marcinmoskala.math.nonDivisiveBy
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class NumbersDivisibleTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/PermutationTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/PermutationTest.kt
@@ -3,8 +3,8 @@ package com.marcinmoskala.math.tests
 import com.marcinmoskala.math.permutations
 import com.marcinmoskala.math.permutationsNumber
 import com.marcinmoskala.math.plusAt
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class PermutationTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/PowerTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/PowerTest.kt
@@ -1,9 +1,9 @@
 package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.pow
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 @Suppress("USELESS_IS_CHECK")
 internal class PowerTest {

--- a/src/test/java/com/marcinmoskala/math/tests/PowersetTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/PowersetTest.kt
@@ -3,8 +3,8 @@ package com.marcinmoskala.math.tests
 import com.marcinmoskala.math.pow
 import com.marcinmoskala.math.powerset
 import com.marcinmoskala.math.powersetSize
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class PowersetTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/ProductTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/ProductTest.kt
@@ -1,8 +1,8 @@
 package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.product
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class ProductTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/SetSplitTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/SetSplitTest.kt
@@ -2,8 +2,8 @@ package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.splits
 import com.marcinmoskala.math.splitsNumber
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class SetSplitTest {
 

--- a/src/test/java/com/marcinmoskala/math/tests/SublistsBySplittersTest.kt
+++ b/src/test/java/com/marcinmoskala/math/tests/SublistsBySplittersTest.kt
@@ -1,8 +1,8 @@
 package com.marcinmoskala.math.tests
 
 import com.marcinmoskala.math.sublistsBySplitters
-import junit.framework.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 internal class SublistsBySplittersTest {
 


### PR DESCRIPTION
While adding new functionality I upgraded following dependencies:
 - gradle to 5.5.1
 - kotlin to 1.3.72
 - JUnit to Jupiter 5.6.1 (got warnings `'Assert' is deprecated. Deprecated in Java`)